### PR TITLE
Fixed overwriting of a bot phrase by user variable

### DIFF
--- a/chatbot/chatbot.js
+++ b/chatbot/chatbot.js
@@ -118,6 +118,7 @@ SimpleChatbot.prototype._outputContent = function (interval) {
   var $container = this._$root.querySelector('.chatbot__items');
   var botContent = botData.content;
   if (Array.isArray(botContent)) {
+    botContent = botContent.slice();
     for (var i = 0, length = botContent.length; i < length; i++) {
       if (botContent[i].indexOf('{{') !== -1) {
         for (let key in this._params) {


### PR DESCRIPTION
В случае, когда реплика бота была представлена в сценарии массивом, и при этом содержала пользовательскую переменную, происходила перезапись реплики в сценарии с заменой плейсхолдера переменной на введенное пользователем значение.
Проблема проявлялась при повторном отображении реплики бота, например в циклическом диалоге, или после сброса диалога.